### PR TITLE
fix flag in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ When the Redis Enterprise servers are *not* publicly available use the internal 
 ### Check a cluster we know is broken
 
 ```
-$ ./dnstracer  -d redis-10002.azure1.mague.com
+$ ./dnstracer  -e redis-10002.azure1.mague.com
 Error - run with --debug for more information or run with --suggest for hints on how to fix
 ```
 


### PR DESCRIPTION
If someone would run the above command under "Check a cluster we know is broken" section `dnstrace` would print usage and exit.

The example contains the debug flag but it should contain the endpoint flag.